### PR TITLE
Mark food jokers for other mods

### DIFF
--- a/cards/frostedprimerib.lua
+++ b/cards/frostedprimerib.lua
@@ -9,6 +9,7 @@ SMODS.Joker {
     blueprint_compat = true,
     eternal_compat = false,
     perishable_compat = true,
+    pools = { Food = true },
     rarity = 2,
     atlas = "NeatoJokers",
     pos = { x = 7, y = 0 }, 

--- a/cards/icecreamsandwich.lua
+++ b/cards/icecreamsandwich.lua
@@ -5,6 +5,7 @@ SMODS.Joker {
     blueprint_compat = true,
     eternal_compat = false,
     perishable_compat = true,
+    pools = { Food = true },
     config = {extra = {Xmult = 5, decrease = 1}},
     rarity = 2,
     atlas = "NeatoJokers",


### PR DESCRIPTION
This marks Frosted Prime Rib and Ice Cream Sandwich as food jokers for other mods. Mostly that does it for Paperback and Cryptid.